### PR TITLE
Url redirection

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -1,0 +1,3 @@
+# Redirections pour le sous-domaine "etsmobile.clubapplets.ca"
+http://etsmobile.clubapplets.ca https://www.clubapplets.ca/projets
+https://etsmobile.clubapplets.ca https://www.clubapplets.ca/projets


### PR DESCRIPTION
Quelques sites utilisaient l'adresse "etsmobile.clubapplets.ca". Depuis la réfection du site web ce lien n'est plus fonctionnel donc le tout est une tentative ayant pour but de refaire fonctionner le tout en pointant vers "clubapplets.ca/projets".