### PR TITLE
Fixed menu bug on /partenaires

### DIFF
--- a/partenaires.html
+++ b/partenaires.html
@@ -111,7 +111,6 @@
   <script async src="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/js/bootstrap.min.js" integrity="sha384-ChfqqxuZUCnJSK3+MXmPNIyE6ZbWh2IMqE241rYiqJxyMiZ6OW/JmZQ5stwEULTy"
   crossorigin="anonymous"></script>
   <script src="js/partners.js"></script>
-  <script src="js/contact.js"></script>
   <script>
     $("#footer").load("footer.html"); 
   </script>


### PR DESCRIPTION
# Issue
**Closes #95**

# Description
It seems like the `/partenaires` page uses both `partenaires.js` and `contact.js`.
Both the js files share the same hamburger menu toggle logic which is causing the menu to appear and disappear almost instantly whenever the user tries to click it (on `/partenaires`).
I'm not sure why it even uses `contact.js`. Maybe it was added by mistake?

Upon removing the `<script src="js/contact.js"></script>`, the menu seems to working properly and I didn't notice any other side effects.

# Working Demo
[fixed_menu.webm](https://github.com/ApplETS/Site-Web-App-ETS/assets/155918717/9228834b-0f62-4c26-81ca-ff5853347e93)

*For a demo of the bug, check out the linked issue #95* 

